### PR TITLE
Included stdbool

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -1,4 +1,5 @@
 #include <util.h>
+#include <stdbool.h>
 
 
 char* itoa(int val, int base){


### PR DESCRIPTION
This fixes a build error when compiling the userland-template using the Makefile. The file `src/util.c` uses `bool`, `true`, and `false` without including `<stdbool.h>`, which causes a compilation failure in i686-elf-gcc.

Tested by building the userland demo program with the official template

This fix ensures clean builds without modifying the compiler flags or libc assumptions